### PR TITLE
GEODE-9999: Update redis API hits/misses stats for string-based comma…

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/RedisStatsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/RedisStatsIntegrationTest.java
@@ -474,27 +474,27 @@ public class RedisStatsIntegrationTest {
   @Test
   public void clientsStat_withConnectAndClose_isCorrect() {
 
-    jedis = new Jedis("localhost", server.getPort(), TIMEOUT);
-    jedis.ping();
+    Jedis jedis2 = new Jedis("localhost", server.getPort(), TIMEOUT);
+    jedis2.ping();
 
     assertThat(redisStats.getConnectedClients()).isEqualTo(1);
 
-    jedis.close();
-    GeodeAwaitility.await().atMost(Duration.ofSeconds(2))
-        .untilAsserted(() -> assertThat(redisStats.getConnectedClients()).isEqualTo(0));
+    jedis2.close();
+
+    assertThat(redisStats.getConnectedClients()).isEqualTo(0);
   }
 
   @Test
   public void connectionsReceivedStat_shouldIncrement_WhenNewConnectionOccurs() {
 
-    jedis = new Jedis("localhost", server.getPort(), TIMEOUT);
-    jedis.ping();
+    Jedis jedis2 = new Jedis("localhost", server.getPort(), TIMEOUT);
+    jedis2.ping();
 
     assertThat(redisStats.getConnectionsReceived()).isEqualTo(1);
 
-    jedis.close();
+    jedis2.close();
 
-    assertThat(redisStats.getConnectionsReceived()).isEqualTo(1);
+    assertThat(redisStats.getConnectedClients()).isEqualTo(0);
   }
 
   // ######################## Server Section ################

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisStats.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisStats.java
@@ -32,6 +32,7 @@ import org.apache.geode.StatisticsFactory;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
@@ -114,6 +115,7 @@ public class RedisStats {
     perSecondExecutor = startPerSecondUpdater();
   }
 
+  @VisibleForTesting
   public void clearAllStats() {
     commandsProcessed.set(0);
     opsPerSecond.set(0);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/CommandHelper.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/CommandHelper.java
@@ -137,12 +137,15 @@ public class CommandHelper {
     return (RedisString) redisData;
   }
 
-  RedisString getRedisString(ByteArrayWrapper key) {
+  RedisString getRedisString(ByteArrayWrapper key, boolean affectsRedisStatistics) {
     RedisData redisData = getRedisData(key, NULL_REDIS_STRING);
+
     if (redisData == NULL_REDIS_STRING) {
-      redisStats.incKeyspaceMisses();
+      if (affectsRedisStatistics)
+        redisStats.incKeyspaceMisses();
     } else {
-      redisStats.incKeyspaceHits();
+      if (affectsRedisStatistics)
+        redisStats.incKeyspaceHits();
     }
 
     return checkStringType(redisData, false);
@@ -150,18 +153,22 @@ public class CommandHelper {
 
   RedisString getRedisStringIgnoringType(ByteArrayWrapper key) {
     RedisData redisData = getRedisData(key, NULL_REDIS_STRING);
+
     if (redisData == NULL_REDIS_STRING) {
       redisStats.incKeyspaceMisses();
     } else {
       redisStats.incKeyspaceHits();
     }
+
     return checkStringType(redisData, true);
   }
 
   RedisString setRedisString(ByteArrayWrapper key, ByteArrayWrapper value) {
     RedisString result;
     RedisData redisData = getRedisData(key);
-    if (redisData.isNull() || redisData.getType() != REDIS_STRING) {
+
+    if (redisData.isNull()
+        || redisData.getType() != REDIS_STRING) {
       redisStats.incKeyspaceMisses();
       result = new RedisString(value);
     } else {
@@ -169,6 +176,7 @@ public class CommandHelper {
       result = (RedisString) redisData;
       result.set(value);
     }
+
     region.put(key, result);
     return result;
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisString.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisString.java
@@ -230,7 +230,7 @@ public class NullRedisString extends RedisString {
       int selfIndex,
       List<ByteArrayWrapper> sourceValues) {
     if (selfIndex != -1) {
-      RedisString redisString = helper.getRedisString(key);
+      RedisString redisString = helper.getRedisString(key, false);
       if (!redisString.isNull()) {
         sourceValues.set(selfIndex, redisString.getValue());
       }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisStringCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisStringCommandsFunctionExecutor.java
@@ -31,8 +31,8 @@ public class RedisStringCommandsFunctionExecutor extends RedisDataCommandsFuncti
     super(helper);
   }
 
-  private RedisString getRedisString(ByteArrayWrapper key) {
-    return helper.getRedisString(key);
+  private RedisString getRedisString(ByteArrayWrapper key, boolean affectsRedisStats) {
+    return helper.getRedisString(key, affectsRedisStats);
   }
 
   private RedisString getRedisStringIgnoringType(ByteArrayWrapper key) {
@@ -42,12 +42,12 @@ public class RedisStringCommandsFunctionExecutor extends RedisDataCommandsFuncti
   @Override
   public long append(ByteArrayWrapper key, ByteArrayWrapper valueToAppend) {
     return stripedExecute(key,
-        () -> getRedisString(key).append(valueToAppend, getRegion(), key));
+        () -> getRedisString(key, false).append(valueToAppend, getRegion(), key));
   }
 
   @Override
   public ByteArrayWrapper get(ByteArrayWrapper key) {
-    return stripedExecute(key, () -> getRedisString(key).get());
+    return stripedExecute(key, () -> getRedisString(key, true).get());
   }
 
   @Override
@@ -63,30 +63,30 @@ public class RedisStringCommandsFunctionExecutor extends RedisDataCommandsFuncti
 
   @Override
   public long incr(ByteArrayWrapper key) {
-    return stripedExecute(key, () -> getRedisString(key).incr(getRegion(), key));
+    return stripedExecute(key, () -> getRedisString(key, false).incr(getRegion(), key));
   }
 
   @Override
   public long decr(ByteArrayWrapper key) {
-    return stripedExecute(key, () -> getRedisString(key).decr(getRegion(), key));
+    return stripedExecute(key, () -> getRedisString(key, false).decr(getRegion(), key));
   }
 
   @Override
   public ByteArrayWrapper getset(ByteArrayWrapper key, ByteArrayWrapper value) {
     return stripedExecute(key,
-        () -> getRedisString(key).getset(getRegion(), key, value));
+        () -> getRedisString(key, false).getset(getRegion(), key, value));
   }
 
   @Override
   public long incrby(ByteArrayWrapper key, long increment) {
     return stripedExecute(key,
-        () -> getRedisString(key).incrby(getRegion(), key, increment));
+        () -> getRedisString(key, false).incrby(getRegion(), key, increment));
   }
 
   @Override
   public double incrbyfloat(ByteArrayWrapper key, double increment) {
     return stripedExecute(key,
-        () -> getRedisString(key)
+        () -> getRedisString(key, false)
             .incrbyfloat(getRegion(), key, increment));
   }
 
@@ -99,46 +99,46 @@ public class RedisStringCommandsFunctionExecutor extends RedisDataCommandsFuncti
   @Override
   public long decrby(ByteArrayWrapper key, long decrement) {
     return stripedExecute(key,
-        () -> getRedisString(key).decrby(getRegion(), key, decrement));
+        () -> getRedisString(key, false).decrby(getRegion(), key, decrement));
   }
 
   @Override
   public ByteArrayWrapper getrange(ByteArrayWrapper key, long start, long end) {
-    return stripedExecute(key, () -> getRedisString(key).getrange(start, end));
+    return stripedExecute(key, () -> getRedisString(key, true).getrange(start, end));
   }
 
   @Override
   public int setrange(ByteArrayWrapper key, int offset, byte[] value) {
     return stripedExecute(key,
-        () -> getRedisString(key)
+        () -> getRedisString(key, false)
             .setrange(getRegion(), key, offset, value));
   }
 
   @Override
   public int bitpos(ByteArrayWrapper key, int bit, int start, Integer end) {
     return stripedExecute(key,
-        () -> getRedisString(key)
+        () -> getRedisString(key, true)
             .bitpos(getRegion(), key, bit, start, end));
   }
 
   @Override
   public long bitcount(ByteArrayWrapper key, int start, int end) {
-    return stripedExecute(key, () -> getRedisString(key).bitcount(start, end));
+    return stripedExecute(key, () -> getRedisString(key, true).bitcount(start, end));
   }
 
   @Override
   public long bitcount(ByteArrayWrapper key) {
-    return stripedExecute(key, () -> getRedisString(key).bitcount());
+    return stripedExecute(key, () -> getRedisString(key, true).bitcount());
   }
 
   @Override
   public int strlen(ByteArrayWrapper key) {
-    return stripedExecute(key, () -> getRedisString(key).strlen());
+    return stripedExecute(key, () -> getRedisString(key, true).strlen());
   }
 
   @Override
   public int getbit(ByteArrayWrapper key, int offset) {
-    return stripedExecute(key, () -> getRedisString(key).getbit(offset));
+    return stripedExecute(key, () -> getRedisString(key, true).getbit(offset));
   }
 
   @Override
@@ -146,7 +146,7 @@ public class RedisStringCommandsFunctionExecutor extends RedisDataCommandsFuncti
     int byteIndex = (int) (offset / 8);
     byte bitIndex = (byte) (offset % 8);
     return stripedExecute(key,
-        () -> getRedisString(key)
+        () -> getRedisString(key, false)
             .setbit(getRegion(), key, value, byteIndex, bitIndex));
   }
 


### PR DESCRIPTION
…nds correctly

- Native redis only updates the hits/misses statistics for operations
  which retrieve data. Currently, our implementation updates these stats
  for operations which also mutate data. This change aligns our
  statistics with native redis.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
